### PR TITLE
Missing `toolName` in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Please note that this redirect page will no longer be required once the Datavers
 curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \
 '{
   "displayName": "Binder",
-  "toolName": "benderPreviewer", 
+  "toolName": "benderExplorer",
   "description": "Run on Binder",
   "scope": "dataset",
   "type": "explore",

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Please note that this redirect page will no longer be required once the Datavers
 curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \
 '{
   "displayName": "Binder",
-  "toolName": "benderExplorer",
+  "toolName": "binderExplorer",
   "description": "Run on Binder",
   "scope": "dataset",
   "type": "explore",

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Please note that this redirect page will no longer be required once the Datavers
 curl -X POST -H 'Content-type: application/json' http://localhost:8080/api/admin/externalTools -d \
 '{
   "displayName": "Binder",
+  "toolName": "benderPreviewer", 
   "description": "Run on Binder",
   "scope": "dataset",
   "type": "explore",


### PR DESCRIPTION
The instructions for adding this tool result in the `toolName` being set to `null`, which is inconsistent with the other tools.

### Steps to Reproduce the Issue
To observe this issue, you can list the external tools using the following command. The tool will appear in the list, but without the `toolName` field: 

```bash
$ curl -s http://localhost:8080/api/admin/externalTools | jq '.data[].toolName'
"textPreviewer"
"htmlPreviewer"
...
"annotationPreviewer"
"mapPreviewer"
"zipPreviewer"
null
```

### Proposed Fix
I've added `benderExplorer` as the `toolName` for this tool to maintain consistency with the other tools. While I’m not certain if **benderExplorer** is the most appropriate or descriptive name, it aligns with the naming convention used by the other tools.